### PR TITLE
Normalize `link()`

### DIFF
--- a/examples/table.js
+++ b/examples/table.js
@@ -1,6 +1,6 @@
 import { create } from '../index';
 import { query } from '../src/query';
-import { link, ownerOf, pathOf, valueOf, atomOf, location } from '../src/meta';
+import { link, ownerOf, pathOf, valueOf, atomOf } from '../src/meta';
 
 export default function Table(T) {
   class Table {
@@ -44,7 +44,8 @@ export default function Table(T) {
         let j = -1;
         for (let _ of row) { //eslint-disable-line
           j++;
-          yield link(create(T), location(T, pathOf(this).concat([i,j])), atomOf(this), ownerOf(this));
+          let owner = ownerOf(this);
+          yield link(create(T), T, pathOf(this).concat([i, j]), atomOf(this), owner.Type, owner.path);
         }
       }
     }
@@ -61,7 +62,8 @@ export default function Table(T) {
       let { table, index } = this;
       for (let _ of valueOf(table)[index]) { //eslint-disable-line
         i++;
-        yield link(create(T), location(T, pathOf(table).concat([index, i])), atomOf(table), ownerOf(table));
+        let owner = ownerOf(table);
+        yield link(create(T), T, pathOf(table).concat([index, i]), atomOf(table), owner.Type, owner.path);
       }
     }
   }
@@ -77,7 +79,8 @@ export default function Table(T) {
       let { table, index } = this;
       for (let _ of valueOf(table)) { //eslint-disable-line
         i++;
-        yield link(create(T), location(T, pathOf(table).concat([i, index])), atomOf(table), ownerOf(table));
+        let owner = ownerOf(table);
+        yield link(create(T), T, pathOf(table).concat([i, index]), atomOf(table), owner.Type, owner.path);
       }
     }
   }

--- a/src/create.js
+++ b/src/create.js
@@ -9,7 +9,7 @@ export default function create(Type, value) {
 
 function transition(object, Type, path, name, method, ...args) {
   let owner = ownerOf(object);
-  let context = link(object, locationOf(object), atomOf(object));
+  let context = link(object, Type, path, atomOf(object));
   let result = method.apply(context, args);
 
   function patch() {
@@ -20,8 +20,7 @@ function transition(object, Type, path, name, method, ...args) {
       return set(lens, result, atomOf(object));
     }
   }
-
-  return link(create(owner.Type), owner, patch());
+  return link(create(owner.Type), owner.Type, owner.path, patch());
 }
 
 function property(object, Type, path, name, currentValue) {

--- a/src/identity.js
+++ b/src/identity.js
@@ -1,6 +1,6 @@
 import MicrostateType from './microstate-type';
 import { At, view, compose, Path } from './lens';
-import { typeOf, valueOf, pathOf, link2, AtomOf } from './meta';
+import { typeOf, valueOf, pathOf, link, AtomOf } from './meta';
 import { treemap } from './tree';
 import create from './create';
 
@@ -32,7 +32,7 @@ export default function Identity(microstate, fn) {
   function transition(Type, name, path, args) {
     let atom = view(Id.value, paths);
     let Root = view(Id.Type, paths);
-    let local = link2(create(Type), Type, path, atom, Root, []);
+    let local = link(create(Type), Type, path, atom, Root, []);
     let next = local[name](...args);
     return paths = identify(next, paths);
   }
@@ -56,7 +56,7 @@ export default function Identity(microstate, fn) {
 
       let value = valueOf(microstate);
 
-      let ref = link2(new Proxy(value), Type, path, 'polymorphic', view(Id.Type, paths), []);
+      let ref = link(new Proxy(value), Type, path, "⚛", view(Id.Type, paths), []);
 
       return {
         [Id.symbol]: new Id(Type, path, value, ref)

--- a/src/meta.js
+++ b/src/meta.js
@@ -6,11 +6,7 @@ export function root(microstate, Type, value) {
   return set(Meta.data, new Meta(new Location(Type, []), value), microstate);
 }
 
-export function link(microstate, location, atom, owner = location) {
-  return set(Meta.data, new Meta(location, atom, owner), microstate);
-}
-
-export function link2(object, Type, path, atom, Owner, ownerPath) {
+export function link(object, Type, path, atom, Owner = Type, ownerPath = path) {
   return set(Meta.data, new Meta(new Location(Type, path), atom, new Location(Owner, ownerPath)), object);
 }
 
@@ -66,10 +62,6 @@ export class Meta {
     let location = new Location(this.location.Type, pathOf(onto).concat(atKey));
     return new Meta(location, atomOf(onto), ownerOf(onto));
   }
-}
-
-export function location(Type, path) {
-  return new Location(Type, path);
 }
 
 class Location {

--- a/tests/lab.test.js
+++ b/tests/lab.test.js
@@ -1,6 +1,6 @@
 import { append } from 'funcadelic';
 import { create, valueOf, atomOf } from '../index';
-import { mount, link, location } from '../src/meta';
+import { mount, link } from '../src/meta';
 import expect from 'expect';
 
 describe('Lab', () => {
@@ -124,14 +124,14 @@ describe('Lab', () => {
       get left() {
         return mount(this, append(create(Hand), {
           get other() {
-            return link(create(Hand), location(Hand, ['right']), atomOf(this), location(Hand, ['left']));
+            return link(create(Hand), Hand, ['right'], atomOf(this), Hand, ['left']);
           }
         }), 'left');
       }
       get right() {
         return mount(this, append(create(Hand), {
           get other() {
-            return link(create(Hand), location(Hand, ['left']), atomOf(this), location(Hand, ['right']));
+            return link(create(Hand), Hand, ['left'], atomOf(this), Hand, ['right']);
           }
         }), 'right');
       }


### PR DESCRIPTION
There were two versions of the `link` function hanging out, `link` and `link2`. Both have a similar functionality, but the first required a knowledge of the meta internal `Location` class which pairs `Type` and `path` together. This change replaces everything with the `link2` which has been renamed to `link`. This version has a slightly more complex interface `(Type, path, atom, Owner, ownerPath)` but does not require knowledge of any complex objects.

In any event these are low-level apis that will rarely be called, and it is expected that the user-land linking function will be much simpler. E.g:

```js
return link(Type, path, owner);
```